### PR TITLE
Move Bounty Hunter config from planner YAML to scenario configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following section describes how to emulate a complete, realistic cyberattack
 To run an operation,  start the Caldera server as usual.
 As starting point, the Bounty Hunter uses a local Caldera agent, i.e., an agent that is running on a system initially controlled by the adversary.
 Since some initial access abilities, e.g., the Nmap Port Scan (`8fcd3afb-75ca-40da-8bff-432abfb00fbb`), need root privileges, start the local agent with root/sudo.
-To run this scenario, configure to use the scenario `demo_initial_access_and_priv_esc` in the Bounty Hunter's configuration (`data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`). 
+To run this scenario, set the scenario in the Bounty Hunter's configuration (`data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`) to `demo_initial_access_and_priv_esc` . 
 The `Bounty Hunter Windows Initial Access and Privilege Escalation Tester` adversary profile was constructed to demonstrate the initial access and privilege escalation capabilities against a Windows or Linux target.
 Alternatively, the `Bounty Hunter - Demo Adversary Profile` can be used as well - which includes all demo abilities for the Bounty Hunter and can be used to demonstrate the various behaviors controlled by the scenario configurations.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Finally, a more detailed description of how the Bounty Hunter works, how it can 
 - Unzip `caldera/plugins/bountyhunter/payloads/payloads.zip` to `caldera/plugins/bountyhunter/payloads`
 - Remember to add the `--build` flag when starting the Caldera server with the Bounty Hunter for the first time
 
+## Docker installation guide
+
+- Download the plugin
+- Copy the `bountyhunter` directory into `caldera/plugins` and enable the plugin in the Caldera server's configuration (`caldera/conf/<config>.yml`)
+- Add the following lines to the `caldera/Dockerfile` to install the Bounty Hunter requirements during the docker build process
+```
+WORKDIR /usr/src/app/plugins/bountyhunter
+RUN pip3 install -r requirements.txt
+```
+- Continue the docker build as usual
+- Note: When using a Caldera docker image, problems during the web ui login might occur ([see here](https://github.com/mitre/caldera/issues/3002)). To avoid problems, add the `--insecure` flag to the docker entry point (`ENTRYPOINT ["python3", "server.py", "--insecure"]`)
+
 # Emulating complete, realistic Cyberattacks with the Bounty Hunter
 
 The following two sections describe two examples how the Bounty Hunter can be used and what it is capable of.

--- a/README.md
+++ b/README.md
@@ -42,18 +42,6 @@ Finally, a more detailed description of how the Bounty Hunter works, how it can 
 - Remember to add the `--build` flag when starting the Caldera server with the Bounty Hunter for the first time
 - Note: The Bounty Hunter works with Caldera v5.0.0 or v4.2.0
 
-## Docker installation guide
-
-- Download the plugin
-- Copy the `bountyhunter` directory into `caldera/plugins` and enable the plugin in the Caldera server's configuration (`caldera/conf/<config>.yml`)
-- Add the following lines to the `caldera/Dockerfile` to install the Bounty Hunter requirements during the docker build process
-```
-WORKDIR /usr/src/app/plugins/bountyhunter
-RUN pip3 install -r requirements.txt
-```
-- Continue the docker build as usual
-- Note: When using a Caldera docker image, problems during the web ui login might occur ([see here](https://github.com/mitre/caldera/issues/3002)). To avoid problems, add the `--insecure` flag to the docker entry point (`ENTRYPOINT ["python3", "server.py", "--insecure"]`)
-
 # Emulating complete, realistic Cyberattacks with the Bounty Hunter
 
 The following two sections describe two examples how the Bounty Hunter can be used and what it is capable of.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This example of how to use these parameters is described in more detail in the s
 The following sections are structured as follows:
 First, a short installation guide is given.
 Then, two examples are introduced that show how the Bounty Hunter can be used and what it is capable of.
-The first example demonstrates the Bounty Hunter's initial access and privilege escalation capabilities and can be used as a guide on how to use it
+The first example demonstrates the Bounty Hunter's initial access and privilege escalation capabilities and can be used as a guide on how to use it.
 The second example shows the high level of complexity of cyberattacks the Bounty Hunter can emulate.
 Finally, a more detailed description of how the Bounty Hunter works, how it can be configured, and how it could be extended is given.
 
@@ -64,8 +64,10 @@ In the second section an example attack based on an APT29 campaign is presented 
 The following section describes how to emulate a complete, realistic cyberattack chain using the Bounty Hunter and can be used as a guide for getting started with it.
 To run an operation,  start the Caldera server as usual.
 As starting point, the Bounty Hunter uses a local Caldera agent, i.e., an agent that is running on a system initially controlled by the adversary.
-Since some initial access abilities, e.g., the Nmap Port Scan (`8fcd3afb-75ca-40da-8bff-432abfb00fbb`), need root privileges, start the local agent with root/sudo. 
-The `Bounty Hunter Windows Initial Access and Privilege Escalation Tester` adversary and the Bounty Hunter's default configuration (`data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`) were constructed to demonstrate the initial access and privilege escalation capabilities against a Windows or Linux target.
+Since some initial access abilities, e.g., the Nmap Port Scan (`8fcd3afb-75ca-40da-8bff-432abfb00fbb`), need root privileges, start the local agent with root/sudo.
+To run this scenario, configure to use the scenario `demo_initial_access_and_priv_esc` in the Bounty Hunter's configuration (`data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`). 
+The `Bounty Hunter Windows Initial Access and Privilege Escalation Tester` adversary profile was constructed to demonstrate the initial access and privilege escalation capabilities against a Windows or Linux target.
+Alternatively, the `Bounty Hunter - Demo Adversary Profile` can be used as well - which includes all demo abilities for the Bounty Hunter and can be used to demonstrate the various behaviors controlled by the scenario configurations.
 
 Before running the operation, some configurations have to be done:
 1. Configure fact `bountyhunter.ip_range`: Using the Caldera UI, configure the IP address range the bounty hunter should scan initially.
@@ -121,9 +123,8 @@ The following section go into more detail about how the Bounty Hunter works, how
 ## Bounty Hunter Configuration
 
 The Bounty Hunter can be configured in many ways to further customize the emulated attack behavior.
-The configuration can be viewed and edited in `bountyhunter/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`.
-Furthermore, the configuration is displayed in the Bounty Hunter's user interface tab (`plugins -> bountyhunter`).
-The configuration can also (partially) be edited using the user interface after pulling [this Caldera branch](https://github.com/L015H4CK/caldera/tree/feature-api-update-planner), which allows updating existing planners using Caldera's API.
+Its parameters can be configured in different scenario config files (`bountyhunter/conf/<scenario_name>/scenario_params.yml`).
+Which scenario to use can be configured in `bountyhunter/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`.
 
 The following table lists the various parameters used by the Bounty Hunter including a short description and the default values.
 
@@ -151,8 +152,8 @@ How far, i.e., how many abilities ahead, the Bounty Hunter uses ability rewards 
 ## Locked Abilities and Manual Reward Updates
 
 Locking abilities and performing manual reward updates enables the Bounty Hunter to perform more realistic, more sophisticated and customized attacks.
-Consider the example adversary `Bounty Hunter - Locked Abilities Demonstrator` with the following abilities: `Find files`, `Stage sensitive files`, `Create staging directory`, `Compress staged directory`, and `Exfil staged directory`.
-Also, the ability `Exfil staged directory` has a high reward value, e.g., `1000`.
+Consider the scenario `demo_locked_abilities` and the example adversary `Bounty Hunter - Locked Abilities Demonstrator` with the following abilities: `Find files`, `Stage sensitive files`, `Create staging directory`, `Compress staged directory`, and `Exfil staged directory`.
+The ability `Exfil staged directory` has a high reward value, e.g., `1000`.
 When using Caldera's Look-Ahead Planner, the agent will execute the following attack chain:
 - Create staging directory
 - Compress staged directory
@@ -166,14 +167,13 @@ Now, the Bounty Hunter can be configured to "lock" the `Compress staged director
 This means, it will only compress the staged directory after files have been staged. See example configuration below.
 
 ```
-params:
-  final_abilities:
-    - ea713bc4-63f0-491c-9a6f-0b01d560b87e        # exfiltrate staged directory
-  locked_abilities:
-    - 300157e5-f4ad-4569-b533-9d1fa0e74d74        # compress staged directory
-  reward_updates:
-    4e97e699-93d7-4040-b5a3-2e906a58199e:         # stage sensitive files
-      300157e5-f4ad-4569-b533-9d1fa0e74d74: 1     # compress staged directory
+final_abilities:
+- ea713bc4-63f0-491c-9a6f-0b01d560b87e        # exfiltrate staged directory
+locked_abilities:
+- 300157e5-f4ad-4569-b533-9d1fa0e74d74        # compress staged directory
+reward_updates:
+4e97e699-93d7-4040-b5a3-2e906a58199e:         # stage sensitive files
+  300157e5-f4ad-4569-b533-9d1fa0e74d74: 1     # compress staged directory
 ```
 
 Now, when running an operation using the Bounty Hunter and the above configuration, the following attack chain is generated and executed:

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ The following section go into more detail about how the Bounty Hunter works, how
 ## Bounty Hunter Configuration
 
 The Bounty Hunter can be configured in many ways to further customize the emulated attack behavior.
-Its parameters can be configured in different scenario config files (`bountyhunter/conf/<scenario_name>/scenario_params.yml`).
-Which scenario to use can be configured in `bountyhunter/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`.
+Its parameters can be configured using scenario configuration files (`bountyhunter/conf/<scenario_name>/scenario_params.yml`).
+The `default` scenario shows all the possible configuration parameters with example values.
+Which scenario the Bounty Hunter should use can be configured in its configuration file (`bountyhunter/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml`).
 
 The following table lists the various parameters used by the Bounty Hunter including a short description and the default values.
 

--- a/app/planners/bounty_hunter.py
+++ b/app/planners/bounty_hunter.py
@@ -389,7 +389,7 @@ class LogicalPlanner:
             ability_reward_tuples.sort(key=lambda t: t[1], reverse=True)
 
         for art in ability_reward_tuples:
-            self.planning_svc.log.debug("<BountyHunter> Shuffled/Sorted Ability Rewards: {}".format(art))
+            self.planning_svc.log.info("<BountyHunter> Shuffled/Sorted Ability Rewards: {}".format(art))
 
         for ability_reward_tuple in ability_reward_tuples:
             for link in executable_links:

--- a/conf/default/scenario_params.yml
+++ b/conf/default/scenario_params.yml
@@ -1,0 +1,23 @@
+name: Default scenario
+description: Default scenario configuration showing all possible parameters.
+seed: 4711
+weighted_random: True
+depth: 3
+discount: 0.9
+default_final_reward: 1000
+default_reward: 1
+default_reward_update: 200
+final_abilities:
+  - ea713bc4-63f0-491c-9a6f-0b01d560b87e             # exfiltrate staged directory
+ability_rewards:
+  4e97e699-93d7-4040-b5a3-2e906a58199e: 1000         # stage sensitive files
+locked_abilities:
+  - 300157e5-f4ad-4569-b533-9d1fa0e74d74             # compress staged directory
+reward_updates:
+  6469befa-748a-4b9c-a96d-f191fde47d89:              # create staging directory
+    4e97e699-93d7-4040-b5a3-2e906a58199e: 10000      # stage sensitive files
+  4e97e699-93d7-4040-b5a3-2e906a58199e:              # stage sensitive files
+    300157e5-f4ad-4569-b533-9d1fa0e74d74: 1          # compress staged directory
+  300157e5-f4ad-4569-b533-9d1fa0e74d74:              # compress staged directory
+    4e97e699-93d7-4040-b5a3-2e906a58199e: -10000     # stage sensitive files
+    90c2efaa-8205-480d-8bb6-61d90dbaf81b: -10000     # find files

--- a/conf/demo_initial_access/scenario_params.yml
+++ b/conf/demo_initial_access/scenario_params.yml
@@ -1,0 +1,4 @@
+name: Initial Access Demo Scenario
+description: Use with adversary profile "Bounty Hunter - Demo Adversary Profile" or "Bounty Hunter - Initial Access Tester" and elevated agent running on host machine.
+final_abilities:
+  - bd527b63-9f9e-46e0-9816-b8434d2b8989           # Current User

--- a/conf/demo_initial_access_and_priv_esc/scenario_params.yml
+++ b/conf/demo_initial_access_and_priv_esc/scenario_params.yml
@@ -1,0 +1,5 @@
+name: Initial Access and Privilege Escalation Demo Scenario
+description: Use with adversary profile "Bounty Hunter - Demo Adversary Profile" or "Bounty Hunter - Initial Access and Privilege Escalation Tester" and elevated agent running on host machine.
+final_abilities:
+  - 8320facd-6bc9-4850-8ecb-02a18064aa91            # Dump /etc/shadow
+  - a440211a-d2cc-4f89-a02d-a39061a0e697            # Credential Dumping via wmidump (mimikatz)

--- a/conf/demo_locked_abilities/scenario_params.yml
+++ b/conf/demo_locked_abilities/scenario_params.yml
@@ -1,13 +1,5 @@
-Name: Locked Ability Demo Scenario
-seed: 4711
-#weighted_random: False
-#depth: 3
-discount: 0.7
-default_final_reward: 1000
-#default_reward: 1
-default_reward_update: 0
-detectability_factor: 1
-success_factor: 1
+name: Locked Ability Demo Scenario
+description: Use with adversary profile "Bounty Hunter - Demo Adversary Profile" or "Bounty Hunter - Locked Abilities Demonstrator" and an agent running on the target machine in group "target".
 final_abilities:
   - ea713bc4-63f0-491c-9a6f-0b01d560b87e           # exfiltrate staged directory
 locked_abilities:

--- a/conf/scenario1/scenario_params.yml
+++ b/conf/scenario1/scenario_params.yml
@@ -1,0 +1,22 @@
+Name: Locked Ability Demo Scenario
+seed: 4711
+#weighted_random: False
+#depth: 3
+discount: 0.7
+default_final_reward: 1000
+#default_reward: 1
+default_reward_update: 0
+detectability_factor: 1
+success_factor: 1
+final_abilities:
+  - ea713bc4-63f0-491c-9a6f-0b01d560b87e           # exfiltrate staged directory
+locked_abilities:
+  - 300157e5-f4ad-4569-b533-9d1fa0e74d74            # compress staged directory
+reward_updates:
+  6469befa-748a-4b9c-a96d-f191fde47d89: # create staging directory
+    4e97e699-93d7-4040-b5a3-2e906a58199e: 1000   # stage sensitive files
+  4e97e699-93d7-4040-b5a3-2e906a58199e: # stage sensitive files
+    300157e5-f4ad-4569-b533-9d1fa0e74d74: 1       # compress staged directory
+  300157e5-f4ad-4569-b533-9d1fa0e74d74: # compress staged directory
+    4e97e699-93d7-4040-b5a3-2e906a58199e: -10000   # stage sensitive files
+    90c2efaa-8205-480d-8bb6-61d90dbaf81b: -10000   # find files

--- a/data/adversaries/0b73bf34-fc5b-48f7-9194-dce993b915b1.yml
+++ b/data/adversaries/0b73bf34-fc5b-48f7-9194-dce993b915b1.yml
@@ -4,14 +4,8 @@ id: 0b73bf34-fc5b-48f7-9194-dce993b915b1
 name: Bounty Hunter - Initial Access Tester
 description: |
   Adversary Profile for Bounty Hunter initial access testing against Windows and Linux Targets.
-  Finds and exfiltrates sensitive files after successful initial access.
+  Find current user name after successful initial access.
 atomic_ordering:
   - 9c109820-6c4d-4378-9a82-00a75323bfda        # Nmap host scan
   - 8fcd3afb-75ca-40da-8bff-432abfb00fbb        # Nmap port scan
-  - 720a3356-eee1-4015-9135-0fc08f7eb2d5        # Find git repositories
-  - 2f90d4de-2612-4468-9251-b220e3727452        # compress git repository
-  - 6469befa-748a-4b9c-a96d-f191fde47d89        # Create staging directory
-  - 4e97e699-93d7-4040-b5a3-2e906a58199e        # stage sensitive files
-  - 90c2efaa-8205-480d-8bb6-61d90dbaf81b        # find files
-  - 300157e5-f4ad-4569-b533-9d1fa0e74d74        # compress staged directory
-  - ea713bc4-63f0-491c-9a6f-0b01d560b87e        # exfil staged directory
+  - bd527b63-9f9e-46e0-9816-b8434d2b8989        # Current User

--- a/data/adversaries/bc784d7e-6761-4472-9050-ce0ab6c0bf3c.yml
+++ b/data/adversaries/bc784d7e-6761-4472-9050-ce0ab6c0bf3c.yml
@@ -1,0 +1,23 @@
+---
+
+id: bc784d7e-6761-4472-9050-ce0ab6c0bf3c
+name: Bounty Hunter - Demo Adversary Profile
+description: |
+  Adversary Profile for Bounty Hunter Demo scenarios.
+  Depending on the selected scenario in the planner's config, the resulting behavior should be either:
+  (1) Perform initial access and collect current user name
+  (2) Perform initial access, privilege escalation and execute ability that needs elevated privileges
+  (3) Find, stage and exfiltrate sensitive files to demonstrate locked abilities
+atomic_ordering:
+  - 9c109820-6c4d-4378-9a82-00a75323bfda        # Nmap host scan (Scenario 1+2)
+  - 8fcd3afb-75ca-40da-8bff-432abfb00fbb        # Nmap port scan (Scenario 1+2)
+  - bd527b63-9f9e-46e0-9816-b8434d2b8989        # Current User (Scenario 1)
+  - ce6628bc-c1e2-456b-91e7-da5b8bcd4005        # Abuse bash can be executed with sudo privileges (Scenario 2)
+  - 0220b3e7-9ba0-4529-abb4-52a70dc49b50        # UAC Bypass via sdctl (Scenario 2)
+  - a440211a-d2cc-4f89-a02d-a39061a0e697        # Dumping credentials via wmidump (Mimikatz) (Scenario 2)
+  - 8320facd-6bc9-4850-8ecb-02a18064aa91        # Dump /etc/shadow (Scenario 2)
+  - 90c2efaa-8205-480d-8bb6-61d90dbaf81b        # Find Files (Scenario 3)
+  - 4e97e699-93d7-4040-b5a3-2e906a58199e        # Stage sensitive files (Scenario 3)
+  - ea713bc4-63f0-491c-9a6f-0b01d560b87e        # Exfil staged directory (Scenario 3)
+  - 6469befa-748a-4b9c-a96d-f191fde47d89        # Create staging directory (Scenario 3)
+  - 300157e5-f4ad-4569-b533-9d1fa0e74d74        # Compress staged directory (Scenario 3)

--- a/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
+++ b/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
@@ -17,22 +17,4 @@ description: |
 module: plugins.bountyhunter.app.planners.bounty_hunter
 ignore_enforcement_modules: []
 params:
-  #seed: 42123
-  #weighted_random: False
-  #depth: 3
-  #discount: 0.9
-  #default_final_reward: 1000
-  #default_reward_update: 500
-  final_abilities:
-    - 8320facd-6bc9-4850-8ecb-02a18064aa91         # Dump /etc/shadow
-    - a440211a-d2cc-4f89-a02d-a39061a0e697         # Credential Dumping via wmidump (mimikatz)
-    #- ea713bc4-63f0-491c-9a6f-0b01d560b87e        # exfiltrate staged directory
-  #ability_rewards:
-  #  4e97e699-93d7-4040-b5a3-2e906a58199e: 1000    # stage sensitive files
-  #locked_abilities:
-  #  - 300157e5-f4ad-4569-b533-9d1fa0e74d74        # compress staged directory
-  #reward_updates:
-    #6469befa-748a-4b9c-a96d-f191fde47d89:         # create staging directory
-      #4e97e699-93d7-4040-b5a3-2e906a58199e: 10000 # stage sensitive files
-    #4e97e699-93d7-4040-b5a3-2e906a58199e:         # stage sensitive files
-      #300157e5-f4ad-4569-b533-9d1fa0e74d74: 1     # compress staged directory
+  scenario: scenario1

--- a/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
+++ b/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
@@ -17,4 +17,4 @@ description: |
 module: plugins.bountyhunter.app.planners.bounty_hunter
 ignore_enforcement_modules: []
 params:
-  scenario: demo_initial_access_and_priv_esc
+  scenario: default

--- a/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
+++ b/data/planners/e1bb9388-1845-495d-b67b-ad61a31ff6cd.yml
@@ -17,4 +17,4 @@ description: |
 module: plugins.bountyhunter.app.planners.bounty_hunter
 ignore_enforcement_modules: []
 params:
-  scenario: scenario1
+  scenario: demo_initial_access_and_priv_esc


### PR DESCRIPTION
This pull request refactors the configuration of the Bounty Hunter.
Instead of configuring its parameters in the planner's YAML file, various scenario configs can now be used to easily switch between scenarios.

Changes:
- Move parameters from planner config to scenario configs
- Add example scenarios
- Change log level of ability reward logging from `debug` to `info` (`debug` includes a lot of logs..)
- Simplify `Bounty Hunter - Initial Access Tester` adversary profile to only execute a single ability after initial access
- Add `Bounty Hunter - Demo Adversary Profile` adversary profile that can be used to demonstrate all scenarios using the different scenario config files