### PR TITLE
Add docker installation guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Finally, a more detailed description of how the Bounty Hunter works, how it can 
 
 - Download the plugin
 - Copy the `bountyhunter` directory into `caldera/plugins` and enable the plugin in the Caldera server's configuration (`caldera/conf/<config>.yml`)
-- Add the following lines to the `caldera/Dockerfile` to install the Bounty Hunter requirements during the docker build process
+- Add the following lines to the `caldera/Dockerfile` to install the Bounty Hunter requirements during the docker build process, e.g., at line 77 after the installation of the emu plugins requirements in lines 69-76 
 ```
 WORKDIR /usr/src/app/plugins/bountyhunter
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
This pull request adds a short installation guide of the Bounty Hunter Plugin for docker installations of Caldera and thus solves https://github.com/fkie-cad/bountyhunter/issues/5.